### PR TITLE
Avoid empty CV workflow commits

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -30,5 +30,4 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git add CV.pdf
-        git commit -m "Update CV.pdf"
-        git push origin main
+        git diff --quiet && echo "No changes to commit" || (git commit -m "Update CV.pdf" && git push origin main)


### PR DESCRIPTION
## Summary
- wrap commit and push in GitHub Action with conditional to prevent empty commits

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68954a0f62d08325b1d08484585ed797