### PR TITLE
Fix LinkedIn URL

### DIFF
--- a/CV.tex
+++ b/CV.tex
@@ -66,7 +66,7 @@
 \textbf{\huge \name} \hfill {\small \faLocationArrow\ Shiraz, Iran} \\ % Name and location
 \hfill \href{tel:\phone}{\underline{\small \faPhone\ \phone}} \\ % Phone number
 \hfill \href{mailto:\email}{\underline{\small \faEnvelope\ \email}} \\ % Email address
-\hfill \href{https://www.linkedin.com/in/mehdikarami}{\underline{\small \faLinkedin\ linkedin.com/in/karami-mehdi}}\\ % LinkedIn profile
+\hfill \href{https://www.linkedin.com/in/karami-mehdi}{\underline{\small \faLinkedin\ linkedin.com/in/karami-mehdi}}\\ % LinkedIn profile
 \hfill \href{https://github.com/karami-mehdi}{\underline{\small \faGithub\ github.com/karami-mehdi}} % GitHub profile
 \end{tabular}
 \end{center}


### PR DESCRIPTION
## Summary
- correct LinkedIn profile URL in contact header

## Testing
- `pdflatex -interaction=nonstopmode CV.tex` *(fails: File `enumitem.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895489e3fe08325ac4b3a65068fcf06